### PR TITLE
Add status:backlog label to repo mode init

### DIFF
--- a/kanban-gh-init/SKILL.md
+++ b/kanban-gh-init/SKILL.md
@@ -404,10 +404,11 @@ Error: Could not find repo '<REPO>'. Check the URL and try again.
 
 ### Create labels
 
-Create all 13 labels (7 status + 3 priority + 3 level) using `gh label create --force` (see `shared/graphql.md` section 8 "Create Labels"). The `--force` flag makes this idempotent — existing labels with the same name get their color and description updated.
+Create all 14 labels (8 status + 3 priority + 3 level) using `gh label create --force` (see `shared/graphql.md` section 8 "Create Labels"). The `--force` flag makes this idempotent — existing labels with the same name get their color and description updated.
 
 ```bash
 # Status labels
+gh label create "status:backlog"      --color "c5def5" --description "Parked for later"                    --repo "$REPO" --force
 gh label create "status:todo"         --color "0e8a16" --description "Not yet started"                    --repo "$REPO" --force
 gh label create "status:plan"         --color "0075ca" --description "Planning in progress"                --repo "$REPO" --force
 gh label create "status:plan-review"  --color "7057ff" --description "Plan awaiting review"                --repo "$REPO" --force
@@ -431,6 +432,7 @@ Print label creation summary:
 
 ```
 Labels:
+  status:backlog      — ✓ created/updated
   status:todo         — ✓ created/updated
   status:plan         — ✓ created/updated
   status:plan-review  — ✓ created/updated
@@ -567,7 +569,7 @@ For org-owned projects, use `github.com/orgs/<OWNER>/projects/<PROJECT_NUMBER>` 
 
   Repo:    <OWNER>/<REPO>
   Mode:    labels (no Project board)
-  Labels:  13 created/updated
+  Labels:  14 created/updated
   Config:  .claude/kanban-gh.json
 
 Add tasks with /kanban-gh add <title>

--- a/shared/graphql.md
+++ b/shared/graphql.md
@@ -532,6 +532,7 @@ Create all required labels on a repo. Uses `--force` to update color/description
 
 ```bash
 # Status labels
+gh label create "status:backlog"      --color "c5def5" --description "Parked for later"                    --repo "$REPO" --force
 gh label create "status:todo"         --color "0e8a16" --description "Not yet started"                    --repo "$REPO" --force
 gh label create "status:plan"         --color "0075ca" --description "Planning in progress"                --repo "$REPO" --force
 gh label create "status:plan-review"  --color "7057ff" --description "Plan awaiting review"                --repo "$REPO" --force


### PR DESCRIPTION
## Summary
- Added `status:backlog` label creation to repo mode initialization in `kanban-gh-init/SKILL.md`
- Added `status:backlog` label to section 8 of `shared/graphql.md`
- Updated label count from 13 to 14 and added to summary list

Fixes #10

## Test plan
- [ ] Run `/kanban-gh-init` in repo mode and verify `status:backlog` label is created
- [ ] Verify label has color `c5def5` and description "Parked for later"
- [ ] Verify init output shows 14 labels
- [ ] Verify `--force` flag is used for idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)