### PR TITLE
fix: init preserves Backlog status on re-run

### DIFF
--- a/kanban-gh-init/SKILL.md
+++ b/kanban-gh-init/SKILL.md
@@ -228,7 +228,7 @@ For each field:
 
 1. **Field does not exist** → create it (see creation commands below).
 2. **Field exists with correct type and all required options present** → skip, no action needed.
-3. **Field exists with correct type but missing required options** → update the field's options using `updateField` from `shared/graphql.md` (section 3b). This is the **common case** for `Status` — every new GitHub Project has a default `Status` field with `Todo`, `In Progress`, `Done`. We replace these with our 7-column pipeline options.
+3. **Field exists with correct type but missing required options** → update the field's options using `updateField` from `shared/graphql.md` (section 3b). This is the **common case** for `Status` — every new GitHub Project has a default `Status` field with `Todo`, `In Progress`, `Done`. We replace these with our 8-column pipeline options (including Backlog).
 4. **Field exists with wrong type** (e.g. `TEXT` instead of `SINGLE_SELECT`) → warn and exit:
 
 ```
@@ -268,7 +268,7 @@ mutation($fieldId: ID!) {
 
 #### Status (SINGLE_SELECT)
 
-Required options (in order): `Todo`, `Plan`, `Plan Review`, `Implement`, `Impl Review`, `Test`, `Done`
+Required options (in order): `Backlog`, `Todo`, `Plan`, `Plan Review`, `Implement`, `Impl Review`, `Test`, `Done`
 
 If field does not exist, create it. If it exists as SINGLE_SELECT but with wrong options, update it using `updateField` (section 3b of `shared/graphql.md`).
 
@@ -281,6 +281,7 @@ mutation($projectId: ID!) {
     dataType: SINGLE_SELECT
     name: "Status"
     singleSelectOptions: [
+      {name: "Backlog",     color: BLUE,   description: "Parked for later"},
       {name: "Todo",        color: GREEN,  description: "Not yet started"},
       {name: "Plan",        color: BLUE,   description: "Planning in progress"},
       {name: "Plan Review", color: PURPLE, description: "Plan awaiting review"},
@@ -294,13 +295,14 @@ mutation($projectId: ID!) {
   }
 }' -f projectId="$PROJECT_ID"
 
-# OR update existing Status field options (common case — new projects have default Status)
+# OR update existing Status field options (common case — new projects have default Status with Backlog preserved)
 FIELD_ID=$(echo "$STATUS_FIELD" | jq -r '.id')
 gh api graphql -f query='
 mutation($fieldId: ID!) {
   updateProjectV2Field(input: {
     fieldId: $fieldId
     singleSelectOptions: [
+      {name: "Backlog",     color: BLUE,   description: "Parked for later"},
       {name: "Todo",        color: GREEN,  description: "Not yet started"},
       {name: "Plan",        color: BLUE,   description: "Planning in progress"},
       {name: "Plan Review", color: PURPLE, description: "Plan awaiting review"},

--- a/shared/graphql.md
+++ b/shared/graphql.md
@@ -230,7 +230,7 @@ mutation($projectId: ID!) {
 
 ### 3b. `updateField`
 
-Update an existing single-select field's options. Use this when a field already exists but has the wrong options (e.g., the default `Status` field on a new GitHub Project has `Todo`, `In Progress`, `Done` — we need to replace these with our 7-column pipeline statuses).
+Update an existing single-select field's options. Use this when a field already exists but has the wrong options (e.g., the default `Status` field on a new GitHub Project has `Todo`, `In Progress`, `Done` — we need to replace these with our 8-column pipeline statuses).
 
 **Important:** `updateProjectV2Field` takes `fieldId` only — NOT `projectId`.
 
@@ -260,6 +260,7 @@ mutation($fieldId: ID!) {
   updateProjectV2Field(input: {
     fieldId: $fieldId
     singleSelectOptions: [
+      {name: "Backlog", color: BLUE, description: "Parked for later"},
       {name: "Todo", color: GREEN, description: "Not yet started"},
       {name: "Plan", color: BLUE, description: "Planning in progress"},
       {name: "Plan Review", color: PURPLE, description: "Plan awaiting review"},


### PR DESCRIPTION
## Summary
- Added `Backlog` as the first Status option in both create and update mutations in `kanban-gh-init/SKILL.md`
- Updated `shared/graphql.md` section 3b `updateField` example to include Backlog (8 statuses total)
- Fixes #9: init no longer wipes the Backlog status option on re-run

## Test plan
- [ ] Run `/kanban-gh-init` on a project that already has Backlog status — verify it is preserved
- [ ] Run `/kanban-gh-init` on a new project — verify Backlog is created as the first option
- [ ] Verify all 8 status options appear in correct order: Backlog, Todo, Plan, Plan Review, Implement, Impl Review, Test, Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)